### PR TITLE
add compatibility for PlayerAbilityLib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ walkers 5.1
 - fix ConcurrentModificationException on AbilityRegistry
 - rework registration of PreyTrait & FearedTrait
 - fix crash when clicking on player
+- add compatibility for PlayerAbilityLib
 
 walkers 5
 ================

--- a/common/src/main/java/tocraft/walkers/api/FlightHelper.java
+++ b/common/src/main/java/tocraft/walkers/api/FlightHelper.java
@@ -1,22 +1,34 @@
 package tocraft.walkers.api;
 
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
+import tocraft.craftedcore.event.Event;
+import tocraft.craftedcore.event.EventFactory;
 
-public class FlightHelper {
+@FunctionalInterface
+public interface FlightHelper {
+    Event<FlightHelper> GRANT = EventFactory.createWithInteractionResult();
+    Event<FlightHelper> REVOKE = EventFactory.createWithInteractionResult();
 
-    public static void grantFlightTo(ServerPlayer player) {
-        player.getAbilities().mayfly = true;
+    InteractionResult event(ServerPlayer player);
+
+    static void grantFlightTo(ServerPlayer player) {
+        if (!GRANT.invoke().event(player).consumesAction()) {
+            player.getAbilities().mayfly = true;
+        }
     }
 
-    public static boolean hasFlight(ServerPlayer player) {
+    static boolean hasFlight(ServerPlayer player) {
         return player.getAbilities().mayfly;
     }
 
-    public static void revokeFlight(ServerPlayer player) {
-        if (player.gameMode.isSurvival()) {
-            player.getAbilities().mayfly = false;
-        }
+    static void revokeFlight(ServerPlayer player) {
+        if (!REVOKE.invoke().event(player).consumesAction()) {
+            if (player.gameMode.isSurvival()) {
+                player.getAbilities().mayfly = false;
+            }
 
-        player.getAbilities().flying = false;
+            player.getAbilities().flying = false;
+        }
     }
 }

--- a/common/src/main/java/tocraft/walkers/integrations/Integrations.java
+++ b/common/src/main/java/tocraft/walkers/integrations/Integrations.java
@@ -16,6 +16,7 @@ public class Integrations {
         register(MoreMobVariantsIntegration.MODID, new MoreMobVariantsIntegration());
         register(MutantMonstersIntegration.MODID, new MutantMonstersIntegration());
         register(AlexMobsIntegration.MODID, new AlexMobsIntegration());
+        register(PlayerAbilityLibIntegration.MODID, new PlayerAbilityLibIntegration());
     }
 
     public static void registerAbilities() {
@@ -58,8 +59,7 @@ public class Integrations {
     }
 
     public static void register(String modid, AbstractIntegration integration) {
-        if (PlatformData.isModLoaded(modid)) {
+        if (PlatformData.isModLoaded(modid))
             INTEGRATIONS.put(modid, integration);
-        }
     }
 }

--- a/common/src/main/java/tocraft/walkers/integrations/impl/PlayerAbilityLibIntegration.java
+++ b/common/src/main/java/tocraft/walkers/integrations/impl/PlayerAbilityLibIntegration.java
@@ -1,0 +1,90 @@
+package tocraft.walkers.integrations.impl;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import org.jetbrains.annotations.Nullable;
+import tocraft.walkers.Walkers;
+import tocraft.walkers.api.FlightHelper;
+import tocraft.walkers.integrations.AbstractIntegration;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class PlayerAbilityLibIntegration extends AbstractIntegration {
+    public static final String MODID = "playerabilitylib";
+    @Nullable
+    private final Object FLYING_MORPH_SOURCE = getAbilitySource(Walkers.id("flying_morph"));
+    @Nullable
+    private final Object ALLOW_FLIGHT_ABILITY = getVanillaFlightAbility();
+
+    @Override
+    public void initialize() {
+        FlightHelper.GRANT.register(player -> {
+            boolean bool = grantFlight(player);
+            return bool ? InteractionResult.SUCCESS : InteractionResult.PASS;
+        });
+        FlightHelper.REVOKE.register(player -> {
+            boolean bool = revokeFlight(player);
+            return bool ? InteractionResult.SUCCESS : InteractionResult.PASS;
+        });
+    }
+
+    @Nullable
+    private Object getAbilitySource(ResourceLocation id) {
+        try {
+            Class<?> palClass = Class.forName("io.github.ladysnake.pal.Pal");
+            Method getAbilitySource = palClass.getMethod("getAbilitySource", ResourceLocation.class);
+            return getAbilitySource.invoke(null, id);
+        } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            error(e);
+            return null;
+        }
+    }
+
+    @Nullable
+    private Object getVanillaFlightAbility() {
+        try {
+            Class<?> vanillaAbilitiesClass = Class.forName("io.github.ladysnake.pal.VanillaAbilities");
+            Field ALLOW_FLYING = vanillaAbilitiesClass.getField("ALLOW_FLYING");
+            return ALLOW_FLYING.get(null);
+        } catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException e) {
+            error(e);
+            return null;
+        }
+    }
+
+    private boolean grantFlight(ServerPlayer player) {
+        if (FLYING_MORPH_SOURCE != null && ALLOW_FLIGHT_ABILITY != null) {
+            try {
+                Class<?> palClass = Class.forName("io.github.ladysnake.pal.Pal");
+                Method grantAbility = palClass.getMethod("grantAbility", Player.class, ALLOW_FLIGHT_ABILITY.getClass(), FLYING_MORPH_SOURCE.getClass());
+                grantAbility.invoke(null, player, ALLOW_FLIGHT_ABILITY, FLYING_MORPH_SOURCE);
+                return true;
+            } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                error(e);
+            }
+        }
+        return false;
+    }
+
+    private boolean revokeFlight(ServerPlayer player) {
+        if (FLYING_MORPH_SOURCE != null && ALLOW_FLIGHT_ABILITY != null) {
+            try {
+                Class<?> palClass = Class.forName("io.github.ladysnake.pal.Pal");
+                Method revokeAbility = palClass.getMethod("revokeAbility", Player.class, ALLOW_FLIGHT_ABILITY.getClass(), FLYING_MORPH_SOURCE.getClass());
+                revokeAbility.invoke(null, player, ALLOW_FLIGHT_ABILITY, FLYING_MORPH_SOURCE);
+                return true;
+            } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                error(e);
+            }
+        }
+        return false;
+    }
+
+    private static void error(Throwable e) {
+        Walkers.LOGGER.error("{} couldn't succeed, there was probably an API change in the PlayerAbilityLib. Please report this!", PlayerAbilityLibIntegration.class, e);
+    }
+}


### PR DESCRIPTION
I've integrated some reflection stuff to use the PlayerAbilityLib when installed in order to change the Flight Permission (or the vanilla methods when the PlayerAbilityLib wasn't found).

fixes https://github.com/ToCraft/woodwalkers-mod/issues/108