### PR TITLE
allow selectors in commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ walkers 5
 - add Mutant Monsters Integration
 - fix ConcurrentModificationException when loading traits
 - fix item pos for allays
+- allow selectors in commands
 
 walkers 4.6
 ================

--- a/common/src/main/java/tocraft/walkers/command/WalkersCommand.java
+++ b/common/src/main/java/tocraft/walkers/command/WalkersCommand.java
@@ -62,6 +62,17 @@ public class WalkersCommand {
          */
         LiteralCommandNode<CommandSourceStack> change2ndShape = Commands.literal("change2ndShape")
                 .then(Commands.argument("player", EntityArgument.players())
+                        .then(Commands.argument("entity", EntityArgument.entity())
+                                .executes(context -> {
+                                    Entity entity = EntityArgument.getEntity(context, "entity");
+                                    CompoundTag nbt = new CompoundTag();
+                                    entity.saveWithoutId(nbt);
+                                    change2ndShape(context.getSource(),
+                                            EntityArgument.getPlayer(context, "player"),
+                                            EntityType.getKey(entity.getType()),
+                                            nbt);
+                                    return 1;
+                                }))
                         .then(Commands.argument("shape", CEntitySummonArgument.id(ctx))
                                 .suggests(SuggestionProviders.SUMMONABLE_ENTITIES).executes(context -> {
                                     change2ndShape(context.getSource(), EntityArgument.getPlayer(context, "player"),
@@ -81,10 +92,22 @@ public class WalkersCommand {
                                         }))))
                 .build();
 
-        LiteralCommandNode<CommandSourceStack> switchShape = Commands.literal("switchShape").then(Commands.argument("player", EntityArgument.players()).then(Commands.literal("normal").executes(context -> {
+        LiteralCommandNode<CommandSourceStack> switchShape = Commands.literal("switchShape").then(Commands.argument("player", EntityArgument.players())
+                        .then(Commands.literal("normal").executes(context -> {
                     switchShapeToNormal(context.getSource(), EntityArgument.getPlayer(context, "player"));
                     return 1;
-                })).then(Commands.argument("shape", CEntitySummonArgument.id(ctx))
+                }))
+                    .then(Commands.argument("entity", EntityArgument.entity())
+                                .executes(context -> {
+                                    Entity entity = EntityArgument.getEntity(context, "entity");
+                                    CompoundTag nbt = new CompoundTag();
+                                    entity.saveWithoutId(nbt);
+                                    switchShape(context.getSource(),
+                                            EntityArgument.getPlayer(context, "player"),
+                                            EntityType.getKey(entity.getType()),
+                                            nbt);
+                                    return 1;
+                                })).then(Commands.argument("shape", CEntitySummonArgument.id(ctx))
                         .suggests(SuggestionProviders.SUMMONABLE_ENTITIES).executes(context -> {
                             switchShape(context.getSource(), EntityArgument.getPlayer(context, "player"),
                                     CEntitySummonArgument.getEntityTypeId(context, "shape"),


### PR DESCRIPTION
implements https://github.com/ToCraft/woodwalkers-mod/issues/115

Note: The commands will only **copy** the entity, you won't be able to control the existing one!