### PR TITLE
Fix first person issue with SpellEngine

### DIFF
--- a/common/src/main/java/dev/tocraft/walkers/mixin/integrations/client/SpellEngineMixin.java
+++ b/common/src/main/java/dev/tocraft/walkers/mixin/integrations/client/SpellEngineMixin.java
@@ -1,0 +1,31 @@
+package dev.tocraft.walkers.mixin.integrations.client;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import dev.tocraft.walkers.api.PlayerShape;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+
+@Pseudo
+@Environment(EnvType.CLIENT)
+@Mixin(targets = "net.spell_engine.client.compatibility.FirstPersonModelCompatibility", remap = false)
+public class SpellEngineMixin
+{
+    @WrapMethod(
+        method = "isActive"
+    )
+    private static boolean wrap_isActive(Operation<Boolean> original)
+    {
+        Player player = Minecraft.getInstance().player;
+        if (player != null &&
+            PlayerShape.getCurrentShape(player) != null)
+        {
+            return true;
+        }
+        return original.call();
+    }
+}

--- a/common/src/main/resources/walkers.mixins.json
+++ b/common/src/main/resources/walkers.mixins.json
@@ -91,7 +91,8 @@
     "client.accessor.RavagerEntityModelAccessor",
     "client.accessor.SpiderEntityModelAccessor",
     "client.accessor.SquidEntityModelAccessor",
-    "integrations.client.BetterCombatMixin"
+    "integrations.client.BetterCombatMixin",
+    "integrations.client.SpellEngineMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This fix resolves #210 but only applies to version 1.20.1.
Newer versions of SpellEngine have modified the FirstPersonModelCompatibility class.