### PR TITLE
Fix max health changes when updating player shape

### DIFF
--- a/common/src/main/java/dev/tocraft/walkers/mixin/player/PlayerEntityDataMixin.java
+++ b/common/src/main/java/dev/tocraft/walkers/mixin/player/PlayerEntityDataMixin.java
@@ -216,12 +216,13 @@ public abstract class PlayerEntityDataMixin extends LivingEntity implements Play
         // health to reflect shape.
         if (shape != null) {
             if (Walkers.CONFIG.scalingHealth && healthAttribute != null) {
-                this.walkers$normalHealth = player.getMaxHealth();
+                this.walkers$normalHealth = (float) healthAttribute.getBaseValue();
 
                 // calculate the current health in percentage, used later
                 float currentHealthPercent = player.getHealth() / player.getMaxHealth();
 
-                healthAttribute.setBaseValue(Math.min(Walkers.CONFIG.maxHealth, shape.getMaxHealth()));
+                AttributeInstance shapeHealthAttribute = shape.getAttribute(Attributes.MAX_HEALTH);
+                healthAttribute.setBaseValue(Math.min(Walkers.CONFIG.maxHealth, shapeHealthAttribute.getBaseValue()));
 
                 // set health
                 if (Walkers.CONFIG.percentScalingHealth) {


### PR DESCRIPTION
In a multi-mod environment, there may be methods to increase max health by adding modifiers to the maxhealth attribute. For example, if a player's base max health is 20 but has a +1 modifier, transforming into another mob will cache walkers$normalHealth as 21. Upon reverting to player form, the base value of max health will be set to walkers$normalHealth (21), but with the original +1 modifier applied. resulting in a player maxhealth of 22. This method allows players to infinitely increase their maxhealth.

This PR is aimed at resolving this issue.