### PR TITLE
Fix BetterCombatMixin

### DIFF
--- a/common/src/main/java/dev/tocraft/walkers/mixin/integrations/client/BetterCombatMixin.java
+++ b/common/src/main/java/dev/tocraft/walkers/mixin/integrations/client/BetterCombatMixin.java
@@ -1,26 +1,39 @@
 package dev.tocraft.walkers.mixin.integrations.client;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.tocraft.walkers.api.PlayerShape;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @SuppressWarnings("UnresolvedMixinReference")
 @Pseudo
 @Environment(EnvType.CLIENT)
-@Mixin(targets = "net.bettercombat.compatibility.CompatibilityFlags", remap = false)
-public class BetterCombatMixin {
-    @Inject(method = "firstPersonRender", at = @At("RETURN"), cancellable = true, require = 0)
-    private static void onFirstPersonRenderCall(CallbackInfoReturnable<Boolean> cir) {
+@Mixin(targets = "net.bettercombat.client.compat.FirstPersonAnimationCompatibility", remap = false)
+public class BetterCombatMixin
+{
+    @WrapOperation(
+        method = "firstPersonMode",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/bettercombat/client/compat/FirstPersonAnimationCompatibility;isCameraModPresent:Z",
+            opcode = Opcodes.GETSTATIC
+        ),
+        require = 0
+    )
+    private static boolean onFirstPersonRenderCall(Operation<Boolean> original)
+    {
         Player player = Minecraft.getInstance().player;
-        if (player != null && PlayerShape.getCurrentShape(player) != null) {
-            cir.setReturnValue(false);
+        if (player != null && PlayerShape.getCurrentShape(player) != null)
+        {
+            return true;
         }
+        return original.call();
     }
 }


### PR DESCRIPTION
BetterCombat moved the first-person compatibility method to another class.
https://github.com/ZsoltMolnarrr/BetterCombat/commit/e642e8c3550953bcfcdfd011d4b6b52b7dd0f9a9
This fix should work for both versions 1.20 and 1.21.
Could you release a version with this fix that supports 1.20.1?