### PR TITLE
Fix the issue that players could still fly after switching to survival mode

### DIFF
--- a/common/src/main/java/tocraft/walkers/mixin/ServerPlayerGameModeMixin.java
+++ b/common/src/main/java/tocraft/walkers/mixin/ServerPlayerGameModeMixin.java
@@ -29,9 +29,14 @@ public class ServerPlayerGameModeMixin {
 
     @Inject(method = "setGameModeForPlayer", at = @At("RETURN"))
     public void onSetGameModeForPlayerReturn(GameType gameModeForPlayer, GameType previousGameModeForPlayer, CallbackInfo ci) {
-        if (gameModeForPlayer.isSurvival() && Walkers.hasFlyingPermissions(this.player)) {
+        if (!gameModeForPlayer.isSurvival()) {
+            return;
+        }
+        if (Walkers.hasFlyingPermissions(this.player)) {
             FlightHelper.grantFlightTo(this.player);
             this.player.getAbilities().flying = walkers$couldFly;
+        } else {
+            FlightHelper.revokeFlight(this.player);
         }
     }
 }


### PR DESCRIPTION
Issue: when installed with [PlayerAbilityLib](https://www.curseforge.com/minecraft/mc-mods/pal), players could still fly after switching to survival mode.
This fix should resolve this issue.
Could you release a version with this fix that supports 1.20.1?